### PR TITLE
Fix PHP 8.1 implicit cast deprecation notice

### DIFF
--- a/src/Basic.php
+++ b/src/Basic.php
@@ -87,9 +87,9 @@ class Basic extends DataValues
 		if($nums == 0) {
 			return 0;
 		} else if(fmod($nums, 2) == 0){
-			$median = ($data[($nums/2) - 1] + $data[$nums/2])/2;
-		} else{
-			$median = $data[$nums/2];
+			$median = ($data[(int)($nums/2) - 1] + $data[(int)($nums/2)])/2;
+		} else {
+			$median = $data[(int)($nums/2)];
 		}
 		
 		// Step 5.


### PR DESCRIPTION
Hey there, I don't know if anybody still maintains this library, but I still use it and since upgrading to PHP 8.1 a deprecation notice has started popping up concerning "implicit conversion" of a float to an int. The follow change fixes the issue for 8.1 and should be safely backwards-compatible with older versions.

Here's hoping... 🤞 