### PR TITLE
remove php constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         }
     ],
 	"require": {
-		"php": "^5.4.0 || ^7.0",
         "phpunit/phpunit": "*"
     },
     "require-dev": {


### PR DESCRIPTION
I've been getting complaints from composer coming from this package. I'm not sure if having a php constraint (I'm on 8.1) is really necessary, so I figure it's simplest to just remove it.